### PR TITLE
Fast sine approximation with table lookup and linear interpolation.

### DIFF
--- a/fast/sin.go
+++ b/fast/sin.go
@@ -48,7 +48,7 @@ func init() {
 	for i := 0; i < sinLen; i++ {
 		sin[i] = math.Sin(float64(i) * step)
 	}
-	for i := 0; i < sinLen-1; i++ {
-		grd[i] = sin[i+1] - sin[i]
+	for i := 0; i < sinLen; i++ {
+		grd[i] = sin[(i+1)%sinLen] - sin[i]
 	}
 }


### PR DESCRIPTION
According to my tests, linear interpolation version is ~%30 faster than current lookup. But in general it did not change performance of benchmark in the audio directory. Still it is a win because of memory gains and better accuracy.
