### PR TITLE
add truncating table-based oscillators.

### DIFF
--- a/audio/proc.go
+++ b/audio/proc.go
@@ -27,45 +27,6 @@ func sampleToHz(s Sample) float64 {
 	return 440 * fast.Exp2(float64(s)*10)
 }
 
-func NewSquare() *Square {
-	o := &Square{}
-	o.inputs("pitch", &o.pitch, "syn", &o.syn)
-	return o
-}
-
-type Square struct {
-	sink
-	pitch Processor // 0.1/oct, 0 == 440Hz
-	syn   trigger
-
-	pos float64
-}
-
-func (o *Square) Process(s []Sample) {
-	o.pitch.Process(s)
-	t := o.syn.Process()
-	p := o.pos
-	hz, lastS := sampleToHz(s[0]), s[0]
-	for i := range s {
-		if o.syn.isTrigger(t[i]) {
-			p = 0
-		}
-		if s[i] != lastS {
-			hz = sampleToHz(s[i])
-		}
-		p += hz
-		if p > waveHz {
-			p -= waveHz
-		}
-		if p > waveHz/2 {
-			s[i] = -1
-		} else {
-			s[i] = 1
-		}
-	}
-	o.pos = p
-}
-
 func NewSin() *Sin {
 	o := &Sin{}
 	o.inputs("pitch", &o.pitch, "syn", &o.syn)

--- a/audio/table.go
+++ b/audio/table.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2015 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audio
+
+import "math"
+
+type TableOsc struct {
+	sink
+	table []float64
+	pitch Processor
+	syn   trigger
+
+	pos float64
+}
+
+func NewTableOsc(table []float64) *TableOsc {
+	w := &TableOsc{table: table}
+	w.inputs("pitch", &w.pitch, "syn", &w.syn)
+	return w
+}
+
+func (w *TableOsc) Process(s []Sample) {
+	p := w.pos
+	w.pitch.Process(s)
+	t := w.syn.Process()
+	hz, lastS := sampleToHz(s[0]), s[0]
+	for i := range s {
+		if w.syn.isTrigger(t[i]) {
+			p = 0
+		}
+		if s[i] != lastS {
+			hz = sampleToHz(s[i])
+		}
+		s[i] = Sample(w.table[int(p)])
+		p += hz / waveHz * float64(len(w.table))
+		for p > float64(len(w.table)-1) {
+			p -= float64(len(w.table))
+		}
+	}
+	w.pos = p
+}
+
+var (
+	bandLimitedSquareTable   []float64
+	bandLimitedTriangleTable []float64
+	bandLimitedSawTable      []float64
+)
+
+func init() {
+	oddHarmonics := []int{1, 3, 5, 7, 9, 11}
+	allHarmonics := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+	nSamples := 1024 * 16
+	bandLimitedSquareTable = newHarmonicTable(nSamples, oddHarmonics, func(k int) float64 { return 1 / float64(k) })
+	bandLimitedTriangleTable = newHarmonicTable(nSamples, oddHarmonics, func(k int) float64 { return 1 / float64(k) / float64(k) })
+	bandLimitedSawTable = newHarmonicTable(nSamples, allHarmonics, func(k int) float64 { return 2. / math.Pi * math.Pow(-1.0, float64(k)) })
+}
+
+func newHarmonicTable(samples int, harmonics []int, amp func(int) float64) []float64 {
+	table := make([]float64, samples)
+	max := 0.0
+	for i := range table {
+		pos := float64(i) / float64(len(table))
+		for _, h := range harmonics {
+			a := 1.0 * amp(h)
+			freq := 2 * math.Pi * float64(h)
+			table[i] += a * math.Sin(freq*pos)
+		}
+		if table[i] > max {
+			max = table[i]
+		}
+	}
+	for i := range table {
+		table[i] /= max
+	}
+	return table
+}
+
+func NewBandLimitedSquare() *TableOsc   { return NewTableOsc(bandLimitedSquareTable) }
+func NewBandLimitedTriangle() *TableOsc { return NewTableOsc(bandLimitedTriangleTable) }
+func NewBandLimitedSaw() *TableOsc      { return NewTableOsc(bandLimitedSawTable) }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -241,6 +241,8 @@ func (o *Object) init() {
 		p = audio.NewQuant()
 	case "rand":
 		p = audio.NewRand()
+	case "saw":
+		p = audio.NewBandLimitedSaw()
 	case "sin":
 		p = audio.NewSin()
 	case "skip":
@@ -248,9 +250,11 @@ func (o *Object) init() {
 	case "sequencer":
 		p = audio.NewStep()
 	case "square":
-		p = audio.NewSquare()
+		p = audio.NewBandLimitedSquare()
 	case "sum":
 		p = audio.NewSum()
+	case "triangle":
+		p = audio.NewBandLimitedTriangle()
 	case "value":
 		p = audio.Value(o.Value)
 	case "gate":
@@ -292,11 +296,14 @@ var kinds = []string{
 	"noise",
 	"quant",
 	"rand",
+	"saw",
 	"sequencer",
+	"square",
 	"sin",
 	"skip",
 	"square",
 	"sum",
+	"triangle",
 	"value",
 
 	"gate",


### PR DESCRIPTION
I included some examples of table-based oscillators for saw, square and
triangle waveforms. These tables are generated based on their sine
harmonic approximations. This apporach avoids aliasing issues as
introduced with the existing Square oscillator, which generates
frequencies above the nyquist rate.