### PR TITLE
Updating imports to point to github.com/gordonklaus/portaudio

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,11 +1,10 @@
 {
 	"ImportPath": "github.com/nf/sigourney",
-	"GoVersion": "devel +97ba656ccd5d Thu Apr 03 11:34:31 2014 +1100",
+	"GoVersion": "go1.5.1",
 	"Deps": [
 		{
-			"ImportPath": "code.google.com/p/portaudio-go/portaudio",
-			"Comment": "null-23",
-			"Rev": "8728fce2d74b17b775b5607d8068f6070ab094b0"
+			"ImportPath": "github.com/gordonklaus/portaudio",
+			"Rev": "c41f752f1e3fa5225a513d761c723f45bfe07b89"
 		},
 		{
 			"ImportPath": "github.com/gorilla/websocket",

--- a/audio/engine_cgo.go
+++ b/audio/engine_cgo.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package audio
 
-import "code.google.com/p/portaudio-go/portaudio"
+import "github.com/gordonklaus/portaudio"
 
 func (e *Engine) Start() error {
 	stream, err := portaudio.OpenDefaultStream(0, 1, waveHz, FrameLength, e.processAudio)

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 	"os/exec"
 	"runtime"
 
-	"code.google.com/p/portaudio-go/portaudio"
+	"github.com/gordonklaus/portaudio"
 	"github.com/rakyll/portmidi"
 
 	"github.com/nf/sigourney/socket"


### PR DESCRIPTION
Which is where code.google.com/p/portaudio-go/portaudio redirects to.
This allows for a clean build and brings the Readme back into line with
reality.

After updating the import path `go build` successfully builds sigourney.
